### PR TITLE
Fixes tests

### DIFF
--- a/test/database.test.js
+++ b/test/database.test.js
@@ -53,18 +53,18 @@ tape('check if postData adds a new entry to database', (t) => {
   resetDatabase();
   postData('Mulino Bianco', 'Abbracci', 500, true, dbConnection, (err, res) => {
     if (err) console.log(err);
-  });
-
-  dbConnection.query('SELECT * FROM biscuits;', (err, res) => {
-    if (err);
-    const expected = {
-      id: 4,
-      name: 'Abbracci',
-      brand: 'Mulino Bianco',
-      chocolate: true,
-      calories: 500 };
-      const actual = res.rows[3];
-      t.deepEquals(expected, actual, 'both rows should have same values');
-      t.end();
+    dbConnection.query('SELECT * FROM biscuits;', (err, res) => {
+      if (err);
+      const expected = {
+        id: 4,
+        name: 'Abbracci',
+        brand: 'Mulino Bianco',
+        chocolate: true,
+        calories: 500 };
+        const actual = res.rows[3];
+        t.deepEquals(expected, actual, 'both rows should have same values');
+        dbConnection.end();
+        t.end();
+    });
   });
 });


### PR DESCRIPTION
dbConnection.end() closes all open connections belonging to the 'dbConnection' pool: https://github.com/mysqljs/mysql/issues/1395

And if we're using a select query to test our insert, the select must be in a nested callback (as both operations are async)

fixes #39
relates #40